### PR TITLE
OVERFLOW-88

### DIFF
--- a/Chunk.cpp
+++ b/Chunk.cpp
@@ -4,8 +4,6 @@
 
 using namespace std;
 
-const string CHUNK_MAP_DISPLAY = "  ";
-
 // Default Constructor
 Chunk::Chunk() {
 	type = INVALID;

--- a/Chunk.h
+++ b/Chunk.h
@@ -8,6 +8,8 @@ enum ChunkType { VALID, INVALID };
 const int ROW_SIZE = 16;
 const int COLUMN_SIZE = 16;
 
+const string CHUNK_MAP_DISPLAY = "  ";
+
 /*
 Chunk class will hold information for a group of 16x16 tiles of the Map
 Chunk can either be valid or invalid, noting it's ability for a player to move onto it

--- a/Game.cpp
+++ b/Game.cpp
@@ -141,7 +141,7 @@ int main() {
 					}
 					break;
 				case UserInputValidation::Action::MAP:
-					worldMap.DisplayMap();
+					manager.DisplayMap();
 					break;
 				case UserInputValidation::Action::HEALTH:
 					cout << "You are at " << myPlayer.GetPlayerHealth() << " health.";

--- a/GameManager.cpp
+++ b/GameManager.cpp
@@ -116,3 +116,11 @@ void GameManager::Display() {
 	map->Display(myPlayer->GetPlayerChunkLocationX(), myPlayer->GetPlayerChunkLocationY(), myPlayer->GetPlayerLocationX(), myPlayer->GetPlayerLocationY());
 }
 
+/*
+* Display Map.
+* Only displays VALID Chunks.
+*/
+void GameManager::DisplayMap()
+{
+	map->DisplayMap(myPlayer->GetPlayerChunkLocationX(), myPlayer->GetPlayerChunkLocationY(), myPlayer->GetPlayerIcon());
+}

--- a/GameManager.h
+++ b/GameManager.h
@@ -25,6 +25,7 @@ public:
 
 	// Displays the map and anything within it
 	void Display();
+	void DisplayMap();
 
 	/*
 	* Returns the Tile address at player's current location.

--- a/Map.cpp
+++ b/Map.cpp
@@ -98,13 +98,21 @@ void Map::DisplayChunkAt(int chunkX, int chunkY) {
 * Display Map.
 * Only displays VALID Chunks.
 */
-void Map::DisplayMap()
+void Map::DisplayMap(int x, int y, wstring icon)
 {
 	ConsoleColors::EnableColor();
 	for (int row = 0; row < numRows; row++) {
 		Chunk *chunksInRow = chunks[row];
-		for (int column = 0; column < numColumns; column++)
-			chunksInRow[column].DisplayChunkInMap();
+		for (int column = 0; column < numColumns; column++) {
+			if (chunksInRow[column].getType() == INVALID)
+				ConsoleColors::SetColor(GRAY);
+			else
+				ConsoleColors::SetColor(LIME_GREEN);
+			if (x == column && y == row)
+				ConsoleColors::wprint(icon);
+			else
+				cout << CHUNK_MAP_DISPLAY;
+		}
 		cout << endl;
 	}
 	ConsoleColors::DisableColor();

--- a/Map.h
+++ b/Map.h
@@ -18,7 +18,7 @@ class Map
 		Map(Chunk**, int, int);
 		Map(string, int, int);
 		//Accessor methods
-		void DisplayMap();
+		void DisplayMap(int, int, wstring);
 		void Display(int, int, int, int);
 		void DisplayChunkAt(int, int);
 		Chunk& GetChunkAt(int r, int c);

--- a/Player.cpp
+++ b/Player.cpp
@@ -53,6 +53,11 @@ void Player::SetPlayerName(string name)
 	playerName = name;
 }
 
+// Player Icon Getter
+wstring Player::GetPlayerIcon() {
+	return playerIcon;
+}
+
 //Player Health Setter/Getter
 int Player::GetPlayerHealth()
 {

--- a/Player.h
+++ b/Player.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include <iostream>
 #include <string>
 #include "UserInputValidation.h"
@@ -16,11 +16,15 @@ private:
 	int playerHealth;
 	int playerChunkLoc[2];		//Player chunk location stored as row and column
 	int playerTileLocation[2];		//Tile that the player is located on
+	wstring playerIcon = L"🧙‍♂️";
 
 public:
 	//Player Name Setter/Getter
 	string GetPlayerName();
 	void SetPlayerName(string name);
+
+	// Player Icon Getter
+	wstring GetPlayerIcon();
 
 	//Player Health Setter/Getter
 	int GetPlayerHealth();


### PR DESCRIPTION
Player icon (wizard emoji) now displays on the minimap when player types 'map'. Would like to pursue other display options aside from the emoji, as it may not display properly on all device types