### PR TITLE
Overflow 121 only spawning in enemies once the dust golem has been defeated

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -60,8 +60,7 @@ int main() {
 	//Initialize Hero's Tree NPC to offer the Branches of Heroes puzzle.
 	worldMap.GetChunkAt(5, 3).GetTileAt(6, 8).SetNPC(new NPC("Hero's Tree", { L"🌲", 3 }, herosTreeDialogue));
 
-	//Initialize starting area enemies
-	manager.SpawnStartingAreaEnemies(worldMap);
+	
 
 	//Set game loop variables
 	bool isGameOver = false;

--- a/Game.cpp
+++ b/Game.cpp
@@ -63,10 +63,7 @@ int main() {
 
 	//Spawning in the Spellbook Thief NPC-- will be more of just text rather than NPC to interact with
 	
-
-	//Initialize starting area enemies
-	manager.SpawnStartingAreaEnemies(worldMap);
-	
+	//Temp spawns of last area. Will be moved once the last map is implemented.
 	manager.SpawnLandOfScrumEnemies(worldMap);
 
 	//Set game loop variables

--- a/GameManager.cpp
+++ b/GameManager.cpp
@@ -421,6 +421,8 @@ void GameManager::GameBattleManager(Player &myPlayer)
 				currentEnemyHealth = GetPlayerLocationTile().GetEnemy()->GetHealth();
 				cout << enemyName << " Health: " << currentEnemyHealth << "\n\n";
 				break;
+
+			// Player chooses the DEFLECT Action-- player will take only half dmg, and enemy will take half dmg of the attack they dealt
 			case UserInputValidation::Action::DEFLECT:
 				cout << playerName << " deflects!\n";
 				myPlayer.SetPlayerHealth(currentPlayerHealth - (enemyAttackDamage / 2));
@@ -433,11 +435,15 @@ void GameManager::GameBattleManager(Player &myPlayer)
 				cout << playerName << " Health: " << currentPlayerHealth << "\n\n";
 				break;
 			case UserInputValidation::Action::RUN:
+				// The player cannot run away from the tutorial battle with the dust golem
 				if (GetPlayerLocationTile().GetEnemy()->GetName() == "Dust Golem")
 				{
+					// run chance is set to 10 for now, meaning the player will 100% of the time fail at running when fighting the dust golem
 					runChance = 10;
 					cout << "Lord Vallonious laughs at you from trying to run from the tutorial battle...\n";
 				}
+
+				// Setting Run chance at a 50% for now-- will be lowered later (thinking 15% as a default)
 				if (runChance <= 5)
 				{
 					cout << "You ran away safely, but the " << GetPlayerLocationTile().GetEnemy()->GetName() << " still remains...\n";
@@ -527,7 +533,7 @@ void GameManager::GameBattleManager(Player &myPlayer)
 				cout << "The enemy dropped an item!";
 			}
 
-			
+			// Getting rid of the instance of the enemy that has been defeated
 			GetPlayerLocationChunk().EnemyDefeted(GetPlayerLocationTile().GetEnemy());
 			return;
 		}

--- a/GameManager.cpp
+++ b/GameManager.cpp
@@ -433,8 +433,11 @@ void GameManager::GameBattleManager(Player &myPlayer)
 				cout << playerName << " Health: " << currentPlayerHealth << "\n\n";
 				break;
 			case UserInputValidation::Action::RUN:
-				
-				
+				if (GetPlayerLocationTile().GetEnemy()->GetName() == "Dust Golem")
+				{
+					runChance = 10;
+					cout << "Lord Vallonious laughs at you from trying to run from the tutorial battle...\n";
+				}
 				if (runChance <= 5)
 				{
 					cout << "You ran away safely, but the " << GetPlayerLocationTile().GetEnemy()->GetName() << " still remains...\n";
@@ -472,6 +475,8 @@ void GameManager::GameBattleManager(Player &myPlayer)
 				myPlayer.SetPlayerHealth(20);
 				cout << "Lord Vallonious pities you, so he has healed you after your battle with the dust golem... he will not be so merciful next time...\n";
 				cout << "Player health: " << myPlayer.GetPlayerHealth();
+				//Initialize starting area enemies
+				SpawnStartingAreaEnemies(*map);
 			}
 
 			//Remove Enemy reference pointers to delete Enemy


### PR DESCRIPTION
Enemies only spawn in once the dust golem has been defeated
Until then, enemies do not spawn on the starting area map
player cannot escape from the first battle either way, so should be good in that sense